### PR TITLE
Check correct module file for timestamp

### DIFF
--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -345,7 +345,8 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
   getOutputTimestamp :: ModuleName -> Make (Maybe UTCTime)
   getOutputTimestamp mn = do
     let filePath = T.unpack $ runModuleName mn
-        erlFile = outputDir </> filePath </> "index.erl"
+        outputName = T.unpack $ atomModuleName mn PureScriptModule <> ".erl"
+        erlFile = outputDir </> filePath </> outputName
         externsFile = outputDir </> filePath </> "externs.json"
     min <$> getTimestamp erlFile <*> getTimestamp externsFile
 


### PR DESCRIPTION
Per discussion on slack: https://functionalprogramming.slack.com/archives/C04NA444H/p1506722962000245

It was always looking for `index.erl`, which almost always doesn't exist. Now checks for specific files like `control_alt@ps.erl` or whatever.